### PR TITLE
[Feat] PostModal 마크업 및 스타일 기능 구현

### DIFF
--- a/src/components/atoms/PostModal/PostModal.jsx
+++ b/src/components/atoms/PostModal/PostModal.jsx
@@ -1,0 +1,29 @@
+import styled from 'styled-components';
+import defaultTheme from '../../../commons/style/themes/default';
+
+export const PostModalUl = styled.ul`
+    width: 390px;
+    padding: 36px 0 28px;
+    border-radius: 8px;
+    background-color: ${defaultTheme.palette.white};
+    position: relative;
+
+    &::after {
+        content: '';
+        position: absolute;
+        top: 16px;
+        left: 50%;
+        transform: translateX(-50%);
+        width: 50px;
+        height: 4px;
+        border-radius: 2px;
+        background-color: ${defaultTheme.palette.gray};
+    }
+`;
+
+export const PostModalList = styled.li`
+    padding: 16px 26px;
+    cursor: pointer;
+    font-size: ${defaultTheme.fontSize.sm};
+    background-color: ${defaultTheme.palette.white};
+`;


### PR DESCRIPTION
### 📝 Description

- [x] 기능 추가 : 피드의 우측 상단 더보기 버튼 클릭 시에 나타나는 Post Modal창의 마크업 및 스타일 기능 구현을 했습니다.(편의를 위해 배경을 검게 했습니다.)

- [ ] 리팩토링 : 리액트 아토믹화를 조금 더 해봐야 할 것 같지만 우선 구현해내는 것에 신경 썼습니다😅

### 💽 Commits
[Feat] PostModal 마크업 및 스타일 기능 구현

### 🖼 결과
<img width="391" alt="스크린샷 2022-12-14 오전 12 56 29" src="https://user-images.githubusercontent.com/91003855/207389515-075cfbb2-d9d3-4a62-8cc8-13179e1cc652.png">



## 🎈 Issue Number
close : #11 
