### PR TITLE
[Design] 채팅 리스트 프로필 이미지 svg파일로 수정

### DIFF
--- a/src/pages/Chat/ChatList.jsx
+++ b/src/pages/Chat/ChatList.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import styled from 'styled-components';
 import TopNavBarBasic from '../../components/molecules/TopNavBarBasic/TopNavBarBasic';
 import BottomNavBarBasic from '../../components/molecules/BottomNavBarBasic/BottomNavBarBasic';
+import ChatUserProfileimg from '../../assets/images/default_profile_feed.svg';
 
 const Chat = styled.section``;
 const ChatBoard = styled.ul`
@@ -25,12 +26,12 @@ const ChatList = styled.li`
     }
 `;
 const ChatProfile = styled.img`
+    background-image: url(${ChatUserProfileimg});
     width: 42px;
     height: 42px;
     border-radius: 21px;
     align-self: center;
     flex-grow: 0;
-    background-color: #dbdbdb;
 `;
 const ChatWrap = styled.div`
     display: flex;


### PR DESCRIPTION
### 📝 Description

- [ ] 기능 추가 : 
- [x] 스타일 : 프로필 이미지 임시 색상으로 해두었던 부분 svg 파일로 수정했습니다
- [ ] 리팩토링 :
- [ ] 문서 수정 :
- [ ] 버그 수정 :
- [ ] 기타 : 

### 💽 Commits

[Design] 채팅 리스트 프로필 이미지 svg파일로 수정

### 🖼 결과

<img width="503" alt="스크린샷 2022-12-22 오전 10 40 48" src="https://user-images.githubusercontent.com/105825302/209036284-3e6cc78d-0440-4061-aeb0-66ff4291e99c.png">

## 🎈 Issue Number
close : #