### PR TITLE
modify profile 프로필 수정 페이지 기존 유저 정보와 이미지 받아오기

### DIFF
--- a/src/components/molecules/TopNavBarSave/TopNavBarSave.jsx
+++ b/src/components/molecules/TopNavBarSave/TopNavBarSave.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState, useContext } from 'react';
 import styled from 'styled-components';
 import BackBtn from '../../atoms/BackBtn/BackBtn';
 import Button from '../../atoms/Button/Button';
@@ -8,17 +8,18 @@ const SaveBtn = styled(Button)`
     margin: 0;
 `;
 
-function TopNavBarSave({ disabled, onClick }) {
+function TopNavBarSave({ disabled, onClick, handleJoinSubmit }) {
     return (
         <TopNavBarHeader>
-        <TopNavBarWrapBg>
-            <BackBtn>
-                <img src={BackBtn} alt="" />
-            </BackBtn>
-            <SaveBtn size="small" type="submit" disabled={!disabled} onClick={onClick}>
-                저장
-            </SaveBtn>
-        </TopNavBarWrapBg>
+            <TopNavBarWrapBg>
+                <BackBtn>
+                    <img src={BackBtn} alt="" />
+                </BackBtn>
+                {/* disabled={!disabled} */}
+                <SaveBtn size="small" type="button" onClick={handleJoinSubmit}>
+                    저장
+                </SaveBtn>
+            </TopNavBarWrapBg>
         </TopNavBarHeader>
     );
 }

--- a/src/pages/ModifyProfile/ModifyProfile.jsx
+++ b/src/pages/ModifyProfile/ModifyProfile.jsx
@@ -1,9 +1,9 @@
-import React, { useState, useEffect, useContext, useNavigate, useRef } from 'react';
+import React, { useState, useEffect, useContext, useRef } from 'react';
 import axios from 'axios';
 import styled from 'styled-components';
 import AuthContext from '../../store/auth-context';
-import { StyledForm } from '../Join/FormStyle';
-import { StyledLabel, StyledInput, ErrorMessage } from '../Join/InputStyle';
+// import { StyledForm } from '../Join/FormStyle';
+// import { StyledLabel, StyledInput } from '../Join/InputStyle';
 import DefaultProfileUserImg from '../../assets/images/default_profile_user.svg';
 import TopNavBarSave from '../../components/molecules/TopNavBarSave/TopNavBarSave';
 import ImageUploadBtn from '../../assets/icons/profile-photo.svg';
@@ -32,8 +32,10 @@ function ModifyProfile() {
 
     const [isDisabled, setIsDisabled] = useState(true); // 버튼 비활성화
 
+    const [msg, setMsg] = useState(''); // 에러메세지
+
     // const [msgUsername, setMsgUsername] = useState('');
-    const [isUsername, setIsUsername] = useState(true);
+    // const [isUsername, setIsUsername] = useState(true);
 
     // username, accountname 둘 중 하나라도 비어있으면 버튼 비활성화 관리
     useEffect(() => {
@@ -61,22 +63,25 @@ function ModifyProfile() {
     const [isAccountname, setIsAccountname] = useState(true);
 
     const authCtx = useContext(AuthContext);
+
     const [data, setData] = useState('');
     const [usernameText, setUsernameText] = useState('');
     const [userId, setUserId] = useState('');
     const [userIntro, setUserIntro] = useState('');
     const [userImg, setUserImg] = useState('');
 
+    // 현재 유저의 데이터 불러오기(인풋창에 표시해주기위함)
     useEffect(() => {
         const getData = () => {
             axios
-                .get(`https://mandarin.api.weniv.co.kr/user/myinfo`, {
+                .get('https://mandarin.api.weniv.co.kr/user/myinfo', {
                     headers: {
                         Authorization: `Bearer ${authCtx.token}`,
+                        'Content-type': 'application/json',
                     },
                 })
                 .then(res => {
-                    console.log(res);
+                    // console.log(res);
                     setData(res.data);
                 })
                 .catch(err => console.log(err));
@@ -84,15 +89,54 @@ function ModifyProfile() {
 
         getData();
     }, []);
+
     useEffect(() => {
         if (data.user) {
-            setUsernameText(data.user.username);
-            setUserId(data.user.accountname);
-            setUserIntro(data.user.intro);
-            setUserImg(data.user.image);
+            setUsername(data.user.username);
+            setAccountname(data.user.accountname);
+            setIntroForm(data.user.intro);
+            setImageSrc(data.user.image);
         }
     }, [data]);
-    // console.log(data.user.username);
+
+    // API - 유저 프로필 수정 사항 갱신하기
+    const handleJoinSubmit = async e => {
+        e.preventDefault();
+        try {
+            const response = await axios.put(
+                'https://mandarin.api.weniv.co.kr/user',
+                {
+                    user: {
+                        accountname: accountName,
+                        username,
+                        intro: introForm,
+                        image: imageSrc,
+                    },
+                },
+                {
+                    headers: {
+                        Authorization: `Bearer ${authCtx.token}`,
+                        'Content-type': 'application/json',
+                    },
+                }
+            );
+
+            const result = await response.data;
+
+            console.log(result);
+
+            if (result.message === '이미 사용중인 계정 ID입니다.') {
+                setMsgAccountname(result.message);
+                setAccountname(result.message);
+                setMsg('* 이미 사용중인 계정 ID입니다.');
+                console.log(result.message);
+                // setIsAccountname(false);
+                // setIsDisabled(true);
+            }
+        } catch (error) {
+            console.error(error);
+        }
+    };
 
     // 이미지파일 인코딩
     const encodeFileToBase64 = fileBlob => {
@@ -106,7 +150,7 @@ function ModifyProfile() {
 
                 formdata.append('image', fileBlob);
 
-                // 이미지 API 통신
+                // 이미지 업데이트
                 const imgres = await axios.post(`https://mandarin.api.weniv.co.kr/image/uploadfile`, {
                     body: formdata,
                 });
@@ -121,18 +165,31 @@ function ModifyProfile() {
     };
 
     // 이미지업로드 버튼을 클릭했을 때 input이 실행
+
     const onClickImageUpload = () => {
         imgInput.current.click();
+        // console.log('확인');
     };
 
+    // ProfileImageInputBtn
+    // ProfileImageUploadInputBtn
     return (
         <LoginWrapper className="login-wrap">
-            <TopNavBarSave />
-            <form style={{ margin: '46px auto 0' }}>
+            <TopNavBarSave handleJoinSubmit={handleJoinSubmit} />
+            <form style={{ margin: '46px auto 0' }} onSubmit={handleJoinSubmit}>
                 <ImageForm>
-                    <ProfileImage src={userImg || null} id="imagePre" onClick={onClickImageUpload} />
-                    <ProfileImageInputBtn>
-                        <ProfileImageUploadInputBtn src={ImageUploadBtn} alt="프로필 업로드 하기" />
+                    <ProfileImage src={imageSrc || userImg} id="imagePre" onClick={onClickImageUpload} />
+                    <ProfileImageInputBtn type="button" onClick={onClickImageUpload}>
+                        <ProfileImageUploadInputBtn
+                            type="file"
+                            id="imgUpload"
+                            accept="image/*"
+                            onChange={e => {
+                                encodeFileToBase64(e.target.files[0]);
+                            }}
+                            name="file"
+                            ref={imgInput}
+                        />
                     </ProfileImageInputBtn>
                 </ImageForm>
 
@@ -144,10 +201,12 @@ function ModifyProfile() {
                         placeholder="2~10자 이내여야 합니다."
                         required
                         defaultValue={usernameText}
+                        value={username}
+                        onChange={e => {
+                            setUsername(e.target.value);
+                        }}
                     />
                 </InputForm>
-
-                {/* <ErrorMessage>* 이미 사용중인 이름입니다.</ErrorMessage> */}
 
                 <InputForm htmlFor="userName">
                     <Label>계정ID</Label>
@@ -157,10 +216,13 @@ function ModifyProfile() {
                         placeholder="영문, 숫자, 특수문자(.), (_)만 사용 가능합니다."
                         required
                         defaultValue={userId}
+                        value={accountName}
+                        onChange={e => {
+                            setAccountname(e.target.value);
+                        }}
                     />
+                    {{ msg } && <ErrorP>{msg}</ErrorP>}
                 </InputForm>
-                {/* <ErrorMessage>* 이미 사용중인 이름입니다.</ErrorMessage> */}
-                {/* <ErrorMessage>* 영문, 숫자, 밑줄 및 마침표만 사용할 수 있습니다.</ErrorMessage> */}
 
                 <InputForm>
                     <Label htmlFor="userIntroduce">소개</Label>
@@ -169,6 +231,10 @@ function ModifyProfile() {
                         id="userIntroduce"
                         placeholder="자신과 판매할 상품에 대해 소개해 주세요!"
                         defaultValue={userIntro}
+                        value={introForm}
+                        onChange={e => {
+                            setIntroForm(e.target.value);
+                        }}
                     />
                 </InputForm>
             </form>

--- a/src/pages/Pages.js
+++ b/src/pages/Pages.js
@@ -9,6 +9,7 @@ import Splash from '../pages/Splash/Splash';
 import Home from '../pages/Home/Home';
 import YourProfile from '../pages/Profile/YourProfile/YourProfile';
 import MyProfile from '../pages/Profile/MyProfile/MyProfile';
+import ModifyProfile from './ModifyProfile/ModifyProfile';
 import Followers from './Followers/Followers';
 import Followings from './Followings/Followings';
 import Chat from '../pages/Chat/ChatList';
@@ -49,6 +50,7 @@ function MainPages() {
                     <Route path="/home" element={<Home />}></Route>
                     <Route path="/yourprofile/:accountName" element={<YourProfile />}></Route>
                     <Route path="/myprofile" element={<MyProfile />}></Route>
+                    <Route path="/modifyProfile" element={<ModifyProfile />}></Route>
                     <Route path="/followers/:accountName" element={<Followers />}></Route>
                     <Route path="/followings/:accountName" element={<Followings />}></Route>
                     <Route path="/chat" element={<Chat />}></Route>


### PR DESCRIPTION
### 📝 Description

- [x] 기능 추가 : 프로필 수정 페이지 이미지 받아오기 안됐던 부분 기능 추가
- [ ] 스타일 : 
- [ ] 리팩토링 :
- [ ] 문서 수정 :
- [ ] 버그 수정 :
- [ ] 기타 : 현재 코드가 조금 더러운 것은 추후에 리팩토링 할 예정입니다...ㅎㅎ

### 💽 Commits
- Pages.js 파일에 프로필 수정 페이지 링크 추가
- ModifyProfile.jsx파일에 프로필 수정 페이지 기능 구현
- TopNavBarSave.jsx파일에 프로필 수정 저장 버튼 코드 추가

### 🖼 결과
<img width="356" alt="스크린샷 2023-01-04 오전 2 53 49" src="https://user-images.githubusercontent.com/91003855/210414130-a400f31f-fe1d-43a1-9c4a-f72be3a0ed60.png">
<img width="389" alt="스크린샷 2023-01-04 오전 2 54 27" src="https://user-images.githubusercontent.com/91003855/210414134-3989ee8f-103a-484d-9c32-6e16010d18a5.png">
<img width="388" alt="스크린샷 2023-01-04 오전 2 55 49" src="https://user-images.githubusercontent.com/91003855/210414138-45409e42-18b9-49c1-8ebf-12e0813628d2.png">


## 🎈 Issue Number
close : #
